### PR TITLE
Replace deprecated pscMake with psc

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ gulp.task("lint", function() {
 gulp.task("make", ["lint"], function() {
   return gulp.src(sources)
     .pipe(plumber())
-    .pipe(purescript.pscMake({ ffi: foreigns }));
+    .pipe(purescript.psc({ ffi: foreigns }));
 });
 
 gulp.task("docs", function () {


### PR DESCRIPTION
see https://github.com/purescript/purescript/wiki/0.7-Migration-Guide#build-process

My info:

``` shell
/tmp/purescript-eff $ psc --version
0.7.0.0
```

Before:

``` shell
/tmp/purescript-eff $ gulp
[19:18:23] Using gulpfile /tmp/purescript-eff/gulpfile.js
[19:18:23] Starting 'lint'...
[19:18:23] Starting 'docs'...
[19:18:23] Starting 'dotpsci'...
[19:18:23] Finished 'lint' after 228 ms
[19:18:23] Starting 'make'...
[19:18:23] Finished 'dotpsci' after 124 ms
[19:18:23] 'make' errored after 90 ms
[19:18:23] Error in plugin 'gulp-purescript'
Message:
    Failed to find psc-make. Please ensure it is available on your system.
[19:18:23] Finished 'docs' after 446 ms
```

After:

``` shell
/tmp/purescript-eff $ gulp
[19:18:52] Using gulpfile /tmp/purescript-eff/gulpfile.js
[19:18:52] Starting 'lint'...
[19:18:52] Starting 'docs'...
[19:18:52] Starting 'dotpsci'...
[19:18:52] Finished 'lint' after 212 ms
[19:18:52] Starting 'make'...
[19:18:52] Finished 'dotpsci' after 125 ms
[19:18:52] Finished 'docs' after 328 ms
[19:18:52] Finished 'make' after 229 ms
[19:18:52] Starting 'default'...
[19:18:52] Finished 'default' after 21 μs
```
