### PR TITLE
make type Pure use an empty row instead of rank-2 types

### DIFF
--- a/docs/Control/Monad/Eff.md
+++ b/docs/Control/Monad/Eff.md
@@ -24,7 +24,7 @@ instance monadEff :: Monad (Eff e)
 #### `Pure`
 
 ``` purescript
-type Pure a = forall e. Eff e a
+type Pure a = Eff () a
 ```
 
 The `Pure` type synonym represents _pure_ computations, i.e. ones in which all effects have been handled.
@@ -38,9 +38,6 @@ runPure :: forall a. Pure a -> a
 ```
 
 Run a pure computation and return its result.
-
-Note: since this function has a rank-2 type, it may cause problems to apply this function using the `$` operator. The recommended approach
-is to use parentheses instead.
 
 #### `untilE`
 

--- a/src/Control/Monad/Eff.purs
+++ b/src/Control/Monad/Eff.purs
@@ -21,12 +21,9 @@ foreign import bindE :: forall e a b. Eff e a -> (a -> Eff e b) -> Eff e b
 -- | The `Pure` type synonym represents _pure_ computations, i.e. ones in which all effects have been handled.
 -- |
 -- | The `runPure` function can be used to run pure computations and obtain their result.
-type Pure a = forall e. Eff e a
+type Pure a = Eff () a
 
 -- | Run a pure computation and return its result.
--- |
--- | Note: since this function has a rank-2 type, it may cause problems to apply this function using the `$` operator. The recommended approach
--- | is to use parentheses instead.
 foreign import runPure :: forall a. Pure a -> a
 
 instance functorEff :: Functor (Eff e) where


### PR DESCRIPTION
Per discussion with paf31 in #purescript. When this was originally written there wasn't syntax for an empty row, now there is so let's use it.

I believe it's also correct then to remove the note about rank-2 types from runPure so I've done that, correct me if I'm wrong.

I can't say I have a completely solid grasp on rank-n types or Eff/row types so I'm not certifying the correctness of this, just pushing the buttons based on my understanding of what was discussed in #purescript.
