### PR TITLE
Add `EffValue` / `EffFn0` and corresponding `run` functions

### DIFF
--- a/src/Control/Monad/Eff/Uncurried.js
+++ b/src/Control/Monad/Eff/Uncurried.js
@@ -60,6 +60,18 @@ exports.mkEffFn10 = function mkEffFn10(fn) {
   };
 };
 
+exports.runEffValue = function runEffValue(v) {
+  return function() {
+    return v;
+  };
+};
+
+exports.runEffFn0 = function runEffFn0(fn) {
+  return function() {
+    return fn();
+  };
+};
+
 exports.runEffFn1 = function runEffFn1(fn) {
   return function(a) {
     return function() {

--- a/src/Control/Monad/Eff/Uncurried.purs
+++ b/src/Control/Monad/Eff/Uncurried.purs
@@ -141,6 +141,8 @@ module Control.Monad.Eff.Uncurried where
 
 import Control.Monad.Eff (kind Effect, Eff)
 
+foreign import data EffValue :: # Effect -> Type -> Type
+foreign import data EffFn0 :: # Effect -> Type -> Type
 foreign import data EffFn1 :: # Effect -> Type -> Type -> Type
 foreign import data EffFn2 :: # Effect -> Type -> Type -> Type -> Type
 foreign import data EffFn3 :: # Effect -> Type -> Type -> Type -> Type -> Type
@@ -173,6 +175,10 @@ foreign import mkEffFn9 :: forall eff a b c d e f g h i r.
 foreign import mkEffFn10 :: forall eff a b c d e f g h i j r.
   (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Eff eff r) -> EffFn10 eff a b c d e f g h i j r
 
+foreign import runEffValue :: forall eff r.
+  EffValue eff r -> Eff eff r
+foreign import runEffFn0 :: forall eff r.
+  EffFn0 eff r -> Eff eff r
 foreign import runEffFn1 :: forall eff a r.
   EffFn1 eff a r -> a -> Eff eff r
 foreign import runEffFn2 :: forall eff a b r.


### PR DESCRIPTION
`EffValue` could be used for reading global properties that are effectful, like `window`, vs `EffFn0` which is functions like `location.reload()`.

It doesn't seem like there would be a need to `mk` these, since they're both normally just `Eff _ Unit`.

Given these things, maybe `Uncurried` isn't quite the right name for this module? It fits with the stuff in `Data.Function` though I guess.