### PR TITLE
[breaking] traverseE

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,5 @@
+{
+  "ignoredDependencies": [
+    "purescript-eff"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,10 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-prelude": "^3.0.0",
+    "purescript-foldable-traversable": "^3.3.0"
+  },
+  "devDependencies": {
+    "purescript-console": "^3.0.0"
   }
 }

--- a/src/Control/Monad/Eff.js
+++ b/src/Control/Monad/Eff.js
@@ -57,3 +57,19 @@ exports.foreachE = function (as) {
     };
   };
 };
+
+exports.traverseEImpl = function (foldl) {
+  return function (xs) {
+    return function (f) {
+      var call = function() {
+        return function(x) {
+          f(x)();
+        };
+      };
+
+      return function () {
+        foldl(call)()(xs);
+      };
+    };
+  };
+};

--- a/src/Control/Monad/Eff.purs
+++ b/src/Control/Monad/Eff.purs
@@ -3,7 +3,7 @@ module Control.Monad.Eff
   , Eff
   , Pure
   , runPure
-  , untilE, whileE, forE, foreachE
+  , untilE, whileE, forE, foreachE, traverseE
   ) where
 
 import Control.Applicative (class Applicative, liftA1)
@@ -12,6 +12,7 @@ import Control.Bind (class Bind)
 import Control.Monad (class Monad, ap)
 
 import Data.Functor (class Functor)
+import Data.Foldable (class Foldable, foldl)
 import Data.Unit (Unit)
 
 -- | The kind of all effect types.
@@ -87,3 +88,17 @@ foreign import forE :: forall e. Int -> Int -> (Int -> Eff e Unit) -> Eff e Unit
 -- | `foreach xs f` runs the computation returned by the function `f` for each
 -- | of the inputs `xs`.
 foreign import foreachE :: forall e a. Array a -> (a -> Eff e Unit) -> Eff e Unit
+
+-- | Loop over a Foldable collection of values.
+-- |
+-- | `traverseE xs f` runs the computation returned by the function `f` for each
+-- | of the inputs `xs`.
+traverseE :: forall e a f. Foldable f => f a -> (a -> Eff e Unit) -> Eff e Unit
+traverseE = traverseEImpl foldl
+
+foreign import traverseEImpl 
+  :: forall e a f
+   . (forall b. (b -> a -> b) -> b -> f a -> b) 
+  -> f a
+  -> (a -> Eff e Unit)
+  -> Eff e Unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,11 @@
+module Test.Main where
+
+import Prelude
+import Control.Monad.Eff (Eff, foreachE, traverseE)
+import Control.Monad.Eff.Console (CONSOLE, log)
+
+main :: forall eff. Eff (console :: CONSOLE | eff) Unit
+main = do
+  let foobar = ["foo", "bar", "bam"]
+  foreachE foobar log
+  traverseE foobar log


### PR DESCRIPTION
Should make it easier and more efficient to write stack-safe traversals. The need for this arose here: https://github.com/purescript/purescript-maps/pull/110

It seemed inefficient to require the use of a temporary, intermediate array to avoid building up `Eff` thunks.