### PR TITLE
Get rid of the row arguments

### DIFF
--- a/src/Control/Monad/Eff.purs
+++ b/src/Control/Monad/Eff.purs
@@ -1,89 +1,62 @@
 module Control.Monad.Eff
-  ( kind Effect
-  , Eff
-  , Pure
-  , runPure
-  , untilE, whileE, forE, foreachE
+  ( Eff
+  , untilE
+  , whileE
+  , forE
+  , foreachE
   ) where
 
 import Control.Applicative (class Applicative, liftA1)
 import Control.Apply (class Apply)
 import Control.Bind (class Bind)
 import Control.Monad (class Monad, ap)
-
 import Data.Functor (class Functor)
 import Data.Unit (Unit)
 
--- | The kind of all effect types.
--- |
--- | Declare new effect types using `foreign data` declarations, as follows:
--- |
--- | ```purescript
--- | import Control.Monad.Eff (kind Effect)
--- |
--- | foreign import data MyEffect :: Effect
--- | ```
-foreign import kind Effect
-
 -- | The `Eff` type constructor is used to represent _native_ effects.
 -- |
--- | See [Handling Native Effects with the Eff Monad](http://www.purescript.org/learn/eff/)
--- | for more details.
--- |
--- | The first type parameter is a row of effects which represents the contexts
--- | in which a computation can be run, and the second type parameter is the
--- | return type.
-foreign import data Eff :: # Effect -> Type -> Type
+-- | The type parameter is the return type of the computation.
+foreign import data Eff :: Type -> Type
 
-instance functorEff :: Functor (Eff e) where
+instance functorEff :: Functor Eff where
   map = liftA1
 
-instance applyEff :: Apply (Eff e) where
+instance applyEff :: Apply Eff where
   apply = ap
 
-instance applicativeEff :: Applicative (Eff e) where
+instance applicativeEff :: Applicative Eff where
   pure = pureE
 
-foreign import pureE :: forall e a. a -> Eff e a
+foreign import pureE :: forall a. a -> Eff a
 
-instance bindEff :: Bind (Eff e) where
+instance bindEff :: Bind Eff where
   bind = bindE
 
-foreign import bindE :: forall e a b. Eff e a -> (a -> Eff e b) -> Eff e b
+foreign import bindE :: forall a b. Eff a -> (a -> Eff b) -> Eff b
 
-instance monadEff :: Monad (Eff e)
-
--- | The `Pure` type synonym represents _pure_ computations, i.e. ones in which
--- | all effects have been handled.
--- |
--- | The `runPure` function can be used to run pure computations and obtain
--- | their result.
-type Pure a = Eff () a
-
--- | Run a pure computation and return its result.
-foreign import runPure :: forall a. Pure a -> a
+instance monadEff :: Monad Eff
 
 -- | Loop until a condition becomes `true`.
 -- |
 -- | `untilE b` is an effectful computation which repeatedly runs the effectful
 -- | computation `b`, until its return value is `true`.
-foreign import untilE :: forall e. Eff e Boolean -> Eff e Unit
+foreign import untilE :: Eff Boolean -> Eff Unit
 
 -- | Loop while a condition is `true`.
 -- |
 -- | `whileE b m` is effectful computation which runs the effectful computation
 -- | `b`. If its result is `true`, it runs the effectful computation `m` and
 -- | loops. If not, the computation ends.
-foreign import whileE :: forall e a. Eff e Boolean -> Eff e a -> Eff e Unit
+foreign import whileE :: forall a. Eff Boolean -> Eff a -> Eff Unit
 
 -- | Loop over a consecutive collection of numbers.
 -- |
 -- | `forE lo hi f` runs the computation returned by the function `f` for each
 -- | of the inputs between `lo` (inclusive) and `hi` (exclusive).
-foreign import forE :: forall e. Int -> Int -> (Int -> Eff e Unit) -> Eff e Unit
+foreign import forE :: Int -> Int -> (Int -> Eff Unit) -> Eff Unit
 
 -- | Loop over an array of values.
 -- |
 -- | `foreachE xs f` runs the computation returned by the function `f` for each
 -- | of the inputs `xs`.
-foreign import foreachE :: forall e a. Array a -> (a -> Eff e Unit) -> Eff e Unit
+foreign import foreachE :: forall a. Array a -> (a -> Eff Unit) -> Eff Unit

--- a/src/Control/Monad/Eff/Class.purs
+++ b/src/Control/Monad/Eff/Class.purs
@@ -10,14 +10,9 @@ import Control.Monad.Eff (Eff)
 -- | transformers.
 -- |
 -- | `liftEff` can be used in any appropriate monad transformer stack to lift an
--- | action of type `Eff eff a` into the monad.
--- |
--- | Note that `MonadEff` is parameterized by the row of effects, so type
--- | inference can be tricky. It is generally recommended to either work with a
--- | polymorphic row of effects, or a concrete, closed row of effects such as
--- | `(trace :: Trace)`.
-class Monad m <= MonadEff eff m | m -> eff where
-  liftEff :: forall a. Eff eff a -> m a
+-- | action of type `Eff a` into the monad.
+class Monad m <= MonadEff m where
+  liftEff :: forall a. Eff a -> m a
 
-instance monadEffEff :: MonadEff eff (Eff eff) where
+instance monadEffEff :: MonadEff Eff where
   liftEff = id

--- a/src/Control/Monad/Eff/Uncurried.purs
+++ b/src/Control/Monad/Eff/Uncurried.purs
@@ -16,13 +16,12 @@
 -- |
 -- | Because there has been no way of giving such functions types, we generally
 -- | resort to converting functions into the normal PureScript form (namely,
--- | a curried function returning an Eff action), and performing the
+-- | a curried function returning an action), and performing the
 -- | marshalling in JavaScript, in the FFI module, like this:
 -- |
 -- | ```purescript
 -- | -- In the PureScript file:
--- | foreign import logMessage :: forall eff.
--- |   String -> String -> Eff (console :: CONSOLE | eff) Unit
+-- | foreign import logMessage :: String -> String -> Eff Unit
 -- | ```
 -- |
 -- | ```javascript
@@ -48,8 +47,7 @@
 -- |
 -- | ```purescript
 -- | -- In the PureScript file:
--- | foreign import logMessageImpl :: forall eff.
--- |   EffFn2 (console :: CONSOLE | eff) String String Unit
+-- | foreign import logMessageImpl :: EffFn2 String String Unit
 -- | ```
 -- |
 -- | ```javascript
@@ -60,8 +58,7 @@
 -- | You can then use `runEffFn2` to provide a nicer version:
 -- |
 -- | ```purescript
--- | logMessage :: forall eff.
--- |   String -> String -> Eff (console :: CONSOLE | eff) Unit
+-- | logMessage :: String -> String -> Eff Unit
 -- | logMessage = runEffFn2 logMessageImpl
 -- | ```
 -- |
@@ -94,11 +91,10 @@
 -- |
 -- | The import then looks like this:
 -- | ```purescript
--- | foreign import logMessageImpl :: forall eff.
--- |  EffFn3 (http :: HTTP, console :: CONSOLE | eff)
+-- | foreign import logMessageImpl ::
+-- |  EffFn3 String
 -- |         String
--- |         String
--- |         (EffFn1 (http :: HTTP, console :: CONSOLE | eff)
+-- |         (EffFn1
 -- |            (Nullable HttpResponse)
 -- |            Unit)
 -- |         Unit
@@ -114,11 +110,11 @@
 -- | PureScript version:
 -- |
 -- | ```purescript
--- | logMessage :: forall eff.
+-- | logMessage ::
 -- |   String ->
 -- |   String ->
--- |   (Nullable HttpResponse -> Eff (http :: HTTP, console :: CONSOLE | eff) Unit) ->
--- |   Eff (http :: HTTP, console :: CONSOLE | eff) Unit
+-- |   (Nullable HttpResponse -> Eff Unit) ->
+-- |   Eff Unit
 -- | logMessage level message callback =
 -- |   runEffFn3 logMessageImpl level message (mkEffFn1 callback)
 -- | ```
@@ -127,69 +123,67 @@
 -- | follows:
 -- |
 -- | * `EffFn{N}` means, a curried function which accepts N arguments and
--- |   performs some effects. The first type argument is the row of effects,
--- |   which works exactly the same way as in `Eff`. The last type argument
--- |   is the return type. All other arguments are the actual function's
--- |   arguments.
+-- |   performs some effects. The type argument represents the return type.
+-- |   All other arguments are the actual function's arguments.
 -- | * `runEffFn{N}` takes an `EffFn` of N arguments, and converts it into the
--- |   normal PureScript form: a curried function which returns an Eff action.
+-- |   normal PureScript form: a curried function which returns an action.
 -- | * `mkEffFn{N}` is the inverse of `runEffFn{N}`. It can be useful for
 -- |   callbacks.
 -- |
 
 module Control.Monad.Eff.Uncurried where
 
-import Control.Monad.Eff (kind Effect, Eff)
+import Control.Monad.Eff (Eff)
 
-foreign import data EffFn1 :: # Effect -> Type -> Type -> Type
-foreign import data EffFn2 :: # Effect -> Type -> Type -> Type -> Type
-foreign import data EffFn3 :: # Effect -> Type -> Type -> Type -> Type -> Type
-foreign import data EffFn4 :: # Effect -> Type -> Type -> Type -> Type -> Type -> Type
-foreign import data EffFn5 :: # Effect -> Type -> Type -> Type -> Type -> Type -> Type -> Type
-foreign import data EffFn6 :: # Effect -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
-foreign import data EffFn7 :: # Effect -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
-foreign import data EffFn8 :: # Effect -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
-foreign import data EffFn9 :: # Effect -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
-foreign import data EffFn10 :: # Effect -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
+foreign import data EffFn1 :: Type -> Type -> Type
+foreign import data EffFn2 :: Type -> Type -> Type -> Type
+foreign import data EffFn3 :: Type -> Type -> Type -> Type -> Type
+foreign import data EffFn4 :: Type -> Type -> Type -> Type -> Type -> Type
+foreign import data EffFn5 :: Type -> Type -> Type -> Type -> Type -> Type -> Type
+foreign import data EffFn6 :: Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
+foreign import data EffFn7 :: Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
+foreign import data EffFn8 :: Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
+foreign import data EffFn9 :: Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
+foreign import data EffFn10 :: Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type -> Type
 
-foreign import mkEffFn1 :: forall eff a r.
-  (a -> Eff eff r) -> EffFn1 eff a r
-foreign import mkEffFn2 :: forall eff a b r.
-  (a -> b -> Eff eff r) -> EffFn2 eff a b r
-foreign import mkEffFn3 :: forall eff a b c r.
-  (a -> b -> c -> Eff eff r) -> EffFn3 eff a b c r
-foreign import mkEffFn4 :: forall eff a b c d r.
-  (a -> b -> c -> d -> Eff eff r) -> EffFn4 eff a b c d r
-foreign import mkEffFn5 :: forall eff a b c d e r.
-  (a -> b -> c -> d -> e -> Eff eff r) -> EffFn5 eff a b c d e r
-foreign import mkEffFn6 :: forall eff a b c d e f r.
-  (a -> b -> c -> d -> e -> f -> Eff eff r) -> EffFn6 eff a b c d e f r
-foreign import mkEffFn7 :: forall eff a b c d e f g r.
-  (a -> b -> c -> d -> e -> f -> g -> Eff eff r) -> EffFn7 eff a b c d e f g r
-foreign import mkEffFn8 :: forall eff a b c d e f g h r.
-  (a -> b -> c -> d -> e -> f -> g -> h -> Eff eff r) -> EffFn8 eff a b c d e f g h r
-foreign import mkEffFn9 :: forall eff a b c d e f g h i r.
-  (a -> b -> c -> d -> e -> f -> g -> h -> i -> Eff eff r) -> EffFn9 eff a b c d e f g h i r
-foreign import mkEffFn10 :: forall eff a b c d e f g h i j r.
-  (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Eff eff r) -> EffFn10 eff a b c d e f g h i j r
+foreign import mkEffFn1 :: forall a r.
+  (a -> Eff r) -> EffFn1 a r
+foreign import mkEffFn2 :: forall a b r.
+  (a -> b -> Eff r) -> EffFn2 a b r
+foreign import mkEffFn3 :: forall a b c r.
+  (a -> b -> c -> Eff r) -> EffFn3 a b c r
+foreign import mkEffFn4 :: forall a b c d r.
+  (a -> b -> c -> d -> Eff r) -> EffFn4 a b c d r
+foreign import mkEffFn5 :: forall a b c d e r.
+  (a -> b -> c -> d -> e -> Eff r) -> EffFn5 a b c d e r
+foreign import mkEffFn6 :: forall a b c d e f r.
+  (a -> b -> c -> d -> e -> f -> Eff r) -> EffFn6 a b c d e f r
+foreign import mkEffFn7 :: forall a b c d e f g r.
+  (a -> b -> c -> d -> e -> f -> g -> Eff r) -> EffFn7 a b c d e f g r
+foreign import mkEffFn8 :: forall a b c d e f g h r.
+  (a -> b -> c -> d -> e -> f -> g -> h -> Eff r) -> EffFn8 a b c d e f g h r
+foreign import mkEffFn9 :: forall a b c d e f g h i r.
+  (a -> b -> c -> d -> e -> f -> g -> h -> i -> Eff r) -> EffFn9 a b c d e f g h i r
+foreign import mkEffFn10 :: forall a b c d e f g h i j r.
+  (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Eff r) -> EffFn10 a b c d e f g h i j r
 
-foreign import runEffFn1 :: forall eff a r.
-  EffFn1 eff a r -> a -> Eff eff r
-foreign import runEffFn2 :: forall eff a b r.
-  EffFn2 eff a b r -> a -> b -> Eff eff r
-foreign import runEffFn3 :: forall eff a b c r.
-  EffFn3 eff a b c r -> a -> b -> c -> Eff eff r
-foreign import runEffFn4 :: forall eff a b c d r.
-  EffFn4 eff a b c d r -> a -> b -> c -> d -> Eff eff r
-foreign import runEffFn5 :: forall eff a b c d e r.
-  EffFn5 eff a b c d e r -> a -> b -> c -> d -> e -> Eff eff r
-foreign import runEffFn6 :: forall eff a b c d e f r.
-  EffFn6 eff a b c d e f r -> a -> b -> c -> d -> e -> f -> Eff eff r
-foreign import runEffFn7 :: forall eff a b c d e f g r.
-  EffFn7 eff a b c d e f g r -> a -> b -> c -> d -> e -> f -> g -> Eff eff r
-foreign import runEffFn8 :: forall eff a b c d e f g h r.
-  EffFn8 eff a b c d e f g h r -> a -> b -> c -> d -> e -> f -> g -> h -> Eff eff r
-foreign import runEffFn9 :: forall eff a b c d e f g h i r.
-  EffFn9 eff a b c d e f g h i r -> a -> b -> c -> d -> e -> f -> g -> h -> i -> Eff eff r
-foreign import runEffFn10 :: forall eff a b c d e f g h i j r.
-  EffFn10 eff a b c d e f g h i j r -> a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Eff eff r
+foreign import runEffFn1 :: forall a r.
+  EffFn1 a r -> a -> Eff r
+foreign import runEffFn2 :: forall a b r.
+  EffFn2 a b r -> a -> b -> Eff r
+foreign import runEffFn3 :: forall a b c r.
+  EffFn3 a b c r -> a -> b -> c -> Eff r
+foreign import runEffFn4 :: forall a b c d r.
+  EffFn4 a b c d r -> a -> b -> c -> d -> Eff r
+foreign import runEffFn5 :: forall a b c d e r.
+  EffFn5 a b c d e r -> a -> b -> c -> d -> e -> Eff r
+foreign import runEffFn6 :: forall a b c d e f r.
+  EffFn6 a b c d e f r -> a -> b -> c -> d -> e -> f -> Eff r
+foreign import runEffFn7 :: forall a b c d e f g r.
+  EffFn7 a b c d e f g r -> a -> b -> c -> d -> e -> f -> g -> Eff r
+foreign import runEffFn8 :: forall a b c d e f g h r.
+  EffFn8 a b c d e f g h r -> a -> b -> c -> d -> e -> f -> g -> h -> Eff r
+foreign import runEffFn9 :: forall a b c d e f g h i r.
+  EffFn9 a b c d e f g h i r -> a -> b -> c -> d -> e -> f -> g -> h -> i -> Eff r
+foreign import runEffFn10 :: forall a b c d e f g h i j r.
+  EffFn10 a b c d e f g h i j r -> a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Eff r

--- a/src/Control/Monad/Eff/Unsafe.js
+++ b/src/Control/Monad/Eff/Unsafe.js
@@ -1,5 +1,5 @@
 "use strict";
 
-exports.unsafeCoerceEff = function (f) {
-  return f;
+exports.unsafePerformEff = function (f) {
+  return f();
 };

--- a/src/Control/Monad/Eff/Unsafe.purs
+++ b/src/Control/Monad/Eff/Unsafe.purs
@@ -1,19 +1,8 @@
 module Control.Monad.Eff.Unsafe where
 
-import Control.Monad.Eff (Eff, runPure)
-import Control.Semigroupoid ((<<<))
-
--- | Change the type of an effectful computation, allowing it to be run in
--- | another context.
--- |
--- | *Note*: use of this function can result in arbitrary side-effects.
-foreign import unsafeCoerceEff
-  :: forall eff1 eff2 a
-   . Eff eff1 a
-  -> Eff eff2 a
+import Control.Monad.Eff (Eff)
 
 -- | Run an effectful computation.
 -- |
 -- | *Note*: use of this function can result in arbitrary side-effects.
-unsafePerformEff :: forall eff a. Eff eff a -> a
-unsafePerformEff = runPure <<< unsafeCoerceEff
+foreign import unsafePerformEff :: forall a. Eff a -> a


### PR DESCRIPTION
Fixes #25.

This does the simplest thing and just removes the row arguments. I know we hadn't come to consensus on the naming yet, but I figured this might catalyze things a bit.

I'm actually fine with keeping the name `Eff`, as long as we document it well. It's obviously the path with the simplest migrations, since people will simply start seeing kind errors, but the same imports will work.