### PR TITLE
Add `Semigroup` and `Monoid` instances for `Eff`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-prelude": "^3.0.0",
+    "purescript-monoid": "^3.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "eslint": "^3.17.1",
-    "pulp": "^10.0.4",
+    "pulp": "^12.0.1",
     "purescript-psa": "^0.5.0-rc.1",
     "rimraf": "^2.6.1"
   }

--- a/src/Control/Monad/Eff.purs
+++ b/src/Control/Monad/Eff.purs
@@ -6,12 +6,14 @@ module Control.Monad.Eff
   , untilE, whileE, forE, foreachE
   ) where
 
-import Control.Applicative (class Applicative, liftA1)
-import Control.Apply (class Apply)
+import Control.Applicative (class Applicative, liftA1, pure)
+import Control.Apply (class Apply, lift2)
 import Control.Bind (class Bind)
 import Control.Monad (class Monad, ap)
 
 import Data.Functor (class Functor)
+import Data.Monoid (class Monoid, mempty)
+import Data.Semigroup (class Semigroup, append)
 import Data.Unit (Unit)
 
 -- | The kind of all effect types.
@@ -34,6 +36,12 @@ foreign import kind Effect
 -- | in which a computation can be run, and the second type parameter is the
 -- | return type.
 foreign import data Eff :: # Effect -> Type -> Type
+
+instance semigroupEff :: Semigroup a => Semigroup (Eff e a) where
+  append = lift2 append
+
+instance monoidEff :: Monoid a => Monoid (Eff e a) where
+  mempty = pure mempty
 
 instance functorEff :: Functor (Eff e) where
   map = liftA1


### PR DESCRIPTION
This commit allows `Eff` values to be combined via the usual `Applicative`-given instances. Also updated Pulp so it wasn't still looking for a `psc` executable.