### PR TITLE
Fix broken link

### DIFF
--- a/src/Control/Monad/Eff.purs
+++ b/src/Control/Monad/Eff.purs
@@ -29,7 +29,7 @@ foreign import kind Effect
 
 -- | The `Eff` type constructor is used to represent _native_ effects.
 -- |
--- | See [Handling Native Effects with the Eff Monad](http://www.purescript.org/learn/eff/)
+-- | See [Handling Native Effects with the Eff Monad](https://github.com/purescript/documentation/blob/master/guides/Eff.md)
 -- | for more details.
 -- |
 -- | The first type parameter is a row of effects which represents the contexts


### PR DESCRIPTION
"Handling Native Effects with the Eff Monad" has been moved and the current link gives a 404. This PR updates the link to the new version of the tutorial.

Alternatively, merge #28 which updates the link to a chapter in the PureScript book.